### PR TITLE
Replace broken footer scraping with static footer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -113,15 +113,4 @@ EOF
 
     cache_key.join('/')
   end
-
-  def parsed_footer
-    if Rails.env.production?
-      Rails.cache.fetch('parsed_footer_value', expires_in: 24.hours) do
-        mechanize = Mechanize.new
-        page = mechanize.get('http://www.doku-zug.ch')
-        footer = page.at('#footer').to_html
-        footer.html_safe
-      end
-    end
-  end
 end

--- a/app/views/dossiers/show.html.haml
+++ b/app/views/dossiers/show.html.haml
@@ -1,32 +1,32 @@
 = render 'search_form'
 
+.contextual
+  - if user_signed_in?
+    = contextual_link('edit', edit_dossier_path(@dossier))
+    - if current_user.role?'admin'
+      = contextual_link('history', dossier_versions_path(@dossier))
+  = contextual_link('print', url_for(:format => :pdf))
+  - if user_signed_in?
+    = contextual_link('excel', url_for(:format => :xls))
+
+%h1#title= @dossier.title
+
+%h3= @dossier.signature
+
+#description= raw(target_blank(@dossier.description))
+
+%h3= t_attr(:keyword_text)
+#keywords.section
+  %ul#keyword-list.keywords= render :partial => 'keyword', :collection => @dossier.keywords.order('name')
+
+- if @dossier.relation_titles.present?
+  %h3= t_attr(:relation_list)
+  #relations.section
+    %ul#relation-list.relations
+      - for relation in @dossier.relation_titles.uniq
+        %li= link_to_relation relation
+
 - cache [@dossier.cache_key, current_user.try(:roles)] do
-  .contextual
-    - if user_signed_in?
-      = contextual_link('edit', edit_dossier_path(@dossier))
-      - if current_user.role?'admin'
-        = contextual_link('history', dossier_versions_path(@dossier))
-    = contextual_link('print', url_for(:format => :pdf))
-    - if user_signed_in?
-      = contextual_link('excel', url_for(:format => :xls))
-
-  %h1#title= @dossier.title
-
-  %h3= @dossier.signature
-
-  #description= raw(target_blank(@dossier.description))
-
-  %h3= t_attr(:keyword_text)
-  #keywords.section
-    %ul#keyword-list.keywords= render :partial => 'keyword', :collection => @dossier.keywords.order('name')
-
-  - if @dossier.relation_titles.present?
-    %h3= t_attr(:relation_list)
-    #relations.section
-      %ul#relation-list.relations
-        - for relation in @dossier.relation_titles.uniq
-          %li= link_to_relation relation
-
   %h3= t_attr(:books)
   #books.section
     %ul
@@ -60,5 +60,5 @@
         - @containers = @dossier.containers
         = render 'containers/list'
 
-- content_for :javascript do
+  - content_for :javascript do
   = highlight_words(@query, 'keywords')

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -51,5 +51,5 @@
               = render :partial => 'shared/flash', :locals => {:flash => flash}
               = yield
           #clear
-      = parsed_footer
+      = render 'shared/public_footer'
     = yield :javascript

--- a/app/views/shared/_public_footer.html
+++ b/app/views/shared/_public_footer.html
@@ -1,0 +1,62 @@
+<div id="footer">
+  <div class="inside">
+    <div id="such">
+      <h1>Öffnungszeiten</h1>
+      <div class="ce_text block">
+        <p>
+          <strong>Montag bis Freitag</strong>
+          <br>9-18 Uhr
+        </p>
+      </div>
+    </div>
+    <div id="seitenkarte">
+      <div class="ce_text block">
+        <h1>Kontakt</h1>
+        <p>
+        <span>doku-zug.ch</span>
+        <br>
+        <span>St.Oswaldsgasse 16</span>
+        <br>
+        <span>Postfach 1146</span>
+        <br>
+        <span>6301 Zug</span>
+        <br>
+        <br>
+        <span>Telefon 041 726 81 81</span>
+        <br>
+        <a href="mailto:info@doku-zug.ch">info@doku-zug.ch</a>
+        <br>
+        <br>
+        <a href="http://www.doku-zug.ch/impressum.html">Impressum</a>
+        </p>
+      </div>
+    </div>
+    <div class="clear"></div>
+    <div id="fusskataloge">
+      <div class="ce_text block">
+        <h1>Kataloge</h1>
+        <p>
+        <a href="http://katalog.doku-zug.ch/" onclick="window.open(this.href);return false" title="Dossierkatalog doku-zug.ch">Suche Dossierkatalog</a>
+        </p>
+        <p>
+        <a href="http://www.winmedio.net/doku-zug/" onclick="window.open(this.href);return false" title="Bücherkatalog doku-zug.ch">Suche Bücherkatalog</a>
+        </p>
+      </div>
+    </div>
+    <div id="schnelllinks">
+      <div class="ce_text block">
+        <h1>Quicklinks</h1>
+        <p>
+        <a href="http://www.hls-dhs-dss.ch/">Historisches Lexikon der Schweiz</a>
+        </p>
+        <p>
+        <a href="http://www.admin.ch/">Schweizerische Eidgenossenschaft</a>
+        </p>
+        <p>
+        <a href="http://www.bibliothekenzug.ch/">Stadt- und Kantonsbibliothek Zug</a>
+        </p>
+      </div>
+    </div>
+    <div class="clear"></div>
+  </div>
+</div>

--- a/app/views/shared/_public_footer.html.haml
+++ b/app/views/shared/_public_footer.html.haml
@@ -1,1 +1,0 @@
-= parsed_footer

--- a/public/404.html
+++ b/public/404.html
@@ -61,16 +61,8 @@
             <h1>Öffnungszeiten</h1>
             <div class="ce_text block">
               <p>
-              <strong>Mo, Di, Mi, Fr</strong>
-              <br>10-18
-              Uhr
-              </p>
-              <p>
-              <span>
-                <strong>Donnerstag</strong>
-                <br>10-20
-                Uhr
-              </span>
+                <strong>Montag bis Freitag</strong>
+                <br>9-18 Uhr
               </p>
             </div>
           </div>

--- a/public/500.html
+++ b/public/500.html
@@ -65,16 +65,8 @@
             <h1>Öffnungszeiten</h1>
             <div class="ce_text block">
               <p>
-              <strong>Mo, Di, Mi, Fr</strong>
-              <br>10-18
-              Uhr
-              </p>
-              <p>
-              <span>
-                <strong>Donnerstag</strong>
-                <br>10-20
-                Uhr
-              </span>
+                <strong>Montag bis Freitag</strong>
+                <br>9-18 Uhr
               </p>
             </div>
           </div>


### PR DESCRIPTION
The previous code started to fail because of a layout change on www.doku-zug.ch. I copied the static footer from the error pages now.