### PR TITLE
Fix sphinxql syntax errors

### DIFF
--- a/app/models/dossiers/sphinx.rb
+++ b/app/models/dossiers/sphinx.rb
@@ -15,7 +15,7 @@ module Dossiers
           match_mode: :extended,
           with: attributes,
           sort_mode: :expr,
-          select: '*, weight() * (1.5 - is_local) AS custom_weight',
+          select: '*, (weight() * (1.5 - is_local)) AS custom_weight',
           order: 'custom_weight DESC',
           max_matches: 1_000_000
         }
@@ -98,7 +98,7 @@ module Dossiers
               '+"' + word + '*"' + ' | ' + '"*' + word + '*"'
             end
           end
-          word_query = "@* (\"#{words.join(' ')}\" | (#{(quoted_words).join(' ')}))"
+          word_query = "@* (\"#{words.join(' ')}\" | (\"#{(quoted_words).join(' ')}\"))"
         end
 
         query = [signature_query, sentence_query, word_query].join(' ')

--- a/app/views/dossiers/show.html.haml
+++ b/app/views/dossiers/show.html.haml
@@ -1,32 +1,32 @@
 = render 'search_form'
 
+.contextual
+  - if user_signed_in?
+    = contextual_link('edit', edit_dossier_path(@dossier))
+    - if current_user.role?'admin'
+      = contextual_link('history', dossier_versions_path(@dossier))
+  = contextual_link('print', url_for(:format => :pdf))
+  - if user_signed_in?
+    = contextual_link('excel', url_for(:format => :xls))
+
+%h1#title= @dossier.title
+
+%h3= @dossier.signature
+
+#description= raw(target_blank(@dossier.description))
+
+%h3= t_attr(:keyword_text)
+#keywords.section
+  %ul#keyword-list.keywords= render :partial => 'keyword', :collection => @dossier.keywords.order('name')
+
+- if @dossier.relation_titles.present?
+  %h3= t_attr(:relation_list)
+  #relations.section
+    %ul#relation-list.relations
+      - for relation in @dossier.relation_titles.uniq
+        %li= link_to_relation relation
+
 - cache [@dossier.cache_key, current_user.try(:roles)] do
-  .contextual
-    - if user_signed_in?
-      = contextual_link('edit', edit_dossier_path(@dossier))
-      - if current_user.role?'admin'
-        = contextual_link('history', dossier_versions_path(@dossier))
-    = contextual_link('print', url_for(:format => :pdf))
-    - if user_signed_in?
-      = contextual_link('excel', url_for(:format => :xls))
-
-  %h1#title= @dossier.title
-
-  %h3= @dossier.signature
-
-  #description= raw(target_blank(@dossier.description))
-
-  %h3= t_attr(:keyword_text)
-  #keywords.section
-    %ul#keyword-list.keywords= render :partial => 'keyword', :collection => @dossier.keywords.order('name')
-
-  - if @dossier.relation_titles.present?
-    %h3= t_attr(:relation_list)
-    #relations.section
-      %ul#relation-list.relations
-        - for relation in @dossier.relation_titles.uniq
-          %li= link_to_relation relation
-
   %h3= t_attr(:books)
   #books.section
     %ul
@@ -60,5 +60,5 @@
         - @containers = @dossier.containers
         = render 'containers/list'
 
-- content_for :javascript do
+  - content_for :javascript do
   = highlight_words(@query, 'keywords')


### PR DESCRIPTION
Fixes these errors:

```
ThinkingSphinx::SyntaxError: sphinxql: syntax error, unexpected '*', expecting FROM or ',' near '* (1.5 - is_local) AS custom_weight FROM `dossier_core`, `dossier_delta` WHERE MATCH('@* (\"\\&\" | (\"\\&\" | \"\\&*\"))') AND `is_topic` = 0 AND `sphinx_deleted` = 0 ORDER BY `custom_weight` DESC LIMIT 0, 20 OPTION field_weights=(title=500, parent_title=5, keywords=10), max_matches=1000000; SHOW META' - SELECT *, weight() * (1.5 - is_local) AS custom_weight FROM `dossier_core`, `dossier_delta` WHERE MATCH('@* (\"\\&\" | (\"\\&\" | \"\\&*\"))') AND `is_topic` = 0 AND `sphinx_deleted` = 0 ORDER BY `custom_weight` DESC LIMIT 0, 20 OPTION field_weights=(title=500, parent_title=5, keywords=10), max_matches=1000000; SHOW META
```

```
ThinkingSphinx::SyntaxError: index dossier_core,dossier_delta: syntax error, unexpected ')' near '+))' - SELECT *, (weight() * (1.5 - is_local)) AS custom_weight FROM `dossier_core`, `dossier_delta` WHERE MATCH('@* (\"+\" | (+))') AND `is_topic` = 0 AND `sphinx_deleted` = 0 ORDER BY `custom_weight` DESC LIMIT 0, 20 OPTION field_weights=(title=500, parent_title=5, keywords=10), max_matches=1000000; SHOW META
```

I'm *assuming* these changes are backwards-compatible with older Sphinx versions :)